### PR TITLE
Disable Gradle configuration cache use on CI

### DIFF
--- a/.github/actions/save-gradle-cache/action.yml
+++ b/.github/actions/save-gradle-cache/action.yml
@@ -73,5 +73,6 @@ runs:
       with:
         path: |
           .gradle
+          !.gradle/configuration-cache
           ~/.gradle/caches/build-cache-*
         key: gradle-build-cache-${{ runner.os }}-${{ inputs.cache-key }}-develop

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -38,13 +38,7 @@ runs:
       with:
         path: |
           .gradle
+          !.gradle/configuration-cache
           ~/.gradle/caches/build-cache-*
         key: gradle-build-cache-${{ runner.os }}-${{ inputs.cache-key }}-develop
 
-    - name: Report restored configuration cache
-      shell: bash
-      run: |
-        echo "--- .gradle ---"
-        ls -la .gradle 2>/dev/null || echo "(no .gradle)"
-        echo "--- .gradle/configuration-cache ---"
-        ls -la .gradle/configuration-cache 2>/dev/null || echo "(no configuration-cache dir)"

--- a/.github/workflows/arch_test.yml
+++ b/.github/workflows/arch_test.yml
@@ -34,7 +34,7 @@ jobs:
           last-fm-shared-secret: ${{ secrets.LAST_FM_SHARED_SECRET }}
           google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON_DEV }}
       - name: Run architecture tests
-        run: ./gradlew :architecture-spec:test
+        run: ./gradlew :architecture-spec:test --no-configuration-cache
       - uses: ./.github/actions/save-gradle-cache
         with:
           use-build-cache: 'true'

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -69,11 +69,12 @@ jobs:
           done
 
       - name: Build debug APK & androidTest APK
-        run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
+        run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --no-configuration-cache
 
       - name: Run E2E tests on ${{ matrix.device }}
         run: |
           bash ${{ matrix.script }} \
+            --no-configuration-cache \
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
 
       - uses: ./.github/actions/save-avd-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Android Lint
         id: lint
-        run: ./gradlew lintDebug --continue
+        run: ./gradlew lintDebug --continue --no-configuration-cache
 
       - uses: ./.github/actions/save-gradle-cache
         with:

--- a/.github/workflows/screenshot_test.yml
+++ b/.github/workflows/screenshot_test.yml
@@ -36,7 +36,7 @@ jobs:
           last-fm-shared-secret: ${{ secrets.LAST_FM_SHARED_SECRET }}
           google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON_DEV }}
       - name: Run screenshot tests
-        run: ./gradlew verifyRoborazziJvm -PonlyScreenshotTest=true
+        run: ./gradlew verifyRoborazziJvm --no-configuration-cache -PonlyScreenshotTest=true
       - uses: ./.github/actions/save-gradle-cache
         with:
           use-build-cache: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           SUNSET_KEY_ALIAS: ${{ secrets.SUNSET_KEY_ALIAS }}
           SUNSET_KEY_PASSWORD: ${{ secrets.SUNSET_KEY_PASSWORD }}
           SUNSET_STORE_PASSWORD: ${{ secrets.SUNSET_STORE_PASSWORD }}
-        run: ./gradlew bundleRelease
+        run: ./gradlew bundleRelease --no-configuration-cache
       - uses: ./.github/actions/save-gradle-cache
         with:
           use-build-cache: 'true'
@@ -67,7 +67,7 @@ jobs:
           last-fm-shared-secret: ${{ secrets.LAST_FM_SHARED_SECRET }}
           google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON_DEV }}
       - name: Run tests
-        run: ./gradlew jvmTest -PexcludeScreenshotTest=true
+        run: ./gradlew jvmTest --no-configuration-cache -PexcludeScreenshotTest=true
       - uses: ./.github/actions/save-gradle-cache
         with:
           use-build-cache: 'true'


### PR DESCRIPTION
Reusing a configuration cache entry between CI runs breaks the GMD test task. Two E2E runs on d5c47e14 restored the same four cache entries; the one that reported "no cached configuration is available" passed, and the one that reported "Reusing configuration cache" failed with:

  Execution failed for task ':app:pixel6Api35DebugAndroidTest'
    > A failure occurred while executing RunUtpWorkAction
       > UtpAction implementation class is missing.

An entry serializes resolved classpaths as absolute paths and is not re-resolved on reuse, so the UTP worker jars it points at are missing on a runner whose Gradle caches were assembled by a different job.

- Pass --no-configuration-cache to the Gradle invocations of the five regular CI workflows: arch_test, lint, screenshot_test, test (both bundleRelease and jvmTest) and e2e_test (both the APK build and the managed-device task reached through scripts/run_e2e_*.sh). The flag overrides org.gradle.configuration-cache=true from gradle.properties, which local builds keep. The release, internal_app_sharing, startup_benchmark and compose_metrics workflows pass use-build-cache: 'false' and so never restore .gradle, and are left alone.
- Exclude .gradle/configuration-cache from the per-job build cache in both setup-gradle and save-gradle-cache, so no entry can survive between runs even if one is written.
- Drop the temporary step that listed the restored configuration cache; the failure above answered what it was added to investigate.

Changing the cache path list changes the version hash actions/cache matches on, so the first run on each ref restores no build cache.